### PR TITLE
Enable encryption mode during bundle initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.10-6</version>
+    <version>2.1.10-7</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -141,6 +141,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> extends Bund
                         //In the base bundle it is created before run and hence this ugly workaround is required.
                         //If we move the init to run, this can be done more elegantly.
                         if(shard == 0 && Objects.nonNull(bundleConfig.getShardingOptions()) && bundleConfig.getShardingOptions().isEncryptionSupportEnabled()) {
+                            shardingOptions = bundleConfig.getShardingOptions();
                             Preconditions.checkArgument(shardingOptions.getEncryptionIv().length() == 16, "Encryption IV Should be 16 bytes long");
                             registerStringEncryptor(null, shardingOptions);
                             registerBigIntegerEncryptor(null, shardingOptions);


### PR DESCRIPTION
In single tenant mode, due to config evaluation issue, encryption types are not getting registered since the hibernate bundle is created before run. To solve for this; I have added a temporary workaround to register types in bundle creation where config can be fetched and evaluated before bundle is initialized. This has to happen only once and is being done on shard 0. 